### PR TITLE
Pass queue to handle_response where it is being used

### DIFF
--- a/lib/logstash/inputs/rss.rb
+++ b/lib/logstash/inputs/rss.rb
@@ -40,7 +40,7 @@ class LogStash::Inputs::Rss < LogStash::Inputs::Base
 
       # Pull down the RSS feed using FTW so we can make use of future cache functions
       response = Faraday.get @url
-      handle_response(response)
+      handle_response(response, queue)
 
       duration = Time.now - start
       @logger.info? && @logger.info("Command completed", :command => @command,
@@ -59,7 +59,7 @@ class LogStash::Inputs::Rss < LogStash::Inputs::Base
     end # loop
   end
 
-  def handle_response(response)
+  def handle_response(response, queue)
     body = response.body
     # @logger.debug("Body", :body => body)
     # Parse the RSS feed


### PR DESCRIPTION
In 43df3839146283cb49ff3889e48527face7bea7e, the code was refactored to extract `handle_response` out of `run`. During this refactoring the `queue` variable was not passed to `handle_response`, even though this method references `queue`. Consequently, the bug reported in #13 occurs. This PR fixes this bug.

Fixes #13 
